### PR TITLE
Add Anenji inverter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The following devices are checked to be supported by the API:
     - EG4® 6000XP All-In-One Off-Grid Inverter
     - EG4® 12kPV All-In-One Hybrid Inverter
     - EG4® 3000EHV-48 All-In-One Off-Grid Inverter
+- **Anenji®**
+    - Anenji® 4200 Watt 24Vdc 220Vac
 
 ## Exported sensors
 
@@ -126,6 +128,7 @@ The following sensors are available via the API:
 | Sorotec, MuscleGrid | [template.yaml](src/template.yaml)                                                                                                                                                                                                                          |                                                                                            |
 | PowMr               | [powmr.yaml](src/powmr.yaml)                                                                                                                                                                                                                                | @lawyerhome @ [issue #1](https://github.com/SilverFire/dessmonitor-homeassistant/issues/1) |
 | EG4®                | [eg4.yaml](src/eg4.yaml)                                                                                                                                                                                                                                    | @Joannou1 @ [issue #3](https://github.com/SilverFire/dessmonitor-homeassistant/issues/3)   |
+| Anenji®             | [anenji.yaml](src/anenji.yaml)                                                                                                                                                                                                                              | @itgenmar @ [issue #22](https://github.com/SilverFire/dessmonitor-homeassistant/issues/22) |
 | Other               | Try using the Sorotec template and adjust if it doesn't work. See [issue #1](https://github.com/SilverFire/dessmonitor-homeassistant/issues/1) as an example. Feel free to submit an issue or a pull request to share your effort with other enthusiasts 🙌 |                                                                                            |
 
 4. Include the `template.yaml` in your `configuration.yaml`:

--- a/src/anenji.yaml
+++ b/src/anenji.yaml
@@ -1,0 +1,98 @@
+- sensor:
+    - name: "Grid Voltage"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_eybond_read_15') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "Grid Frequency"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_eybond_read_16') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "Hz"
+      device_class: "frequency"
+      state_class: "measurement"
+
+    - name: "Grid Power"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_grid_active_power') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+
+    - name: "AC Charging Current"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_eybond_read_45') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "A"
+      device_class: "current"
+      state_class: "measurement"
+
+    - name: "PV1 Voltage"
+      state: >
+        {% set pv_items = state_attr('sensor.inverter_data', 'pv_') %}
+        {{ (pv_items | selectattr('id', 'equalto', 'pv_eybond_read_32') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "PV1 Current"
+      state: >
+        {% set pv_items = state_attr('sensor.inverter_data', 'pv_') %}
+        {{ (pv_items | selectattr('id', 'equalto', 'pv_eybond_read_33') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "A"
+      device_class: "current"
+      state_class: "measurement"
+
+    - name: "PV1 Power"
+      state: >
+        {% set pv_items = state_attr('sensor.inverter_data', 'pv_') %}
+        {{ (pv_items | selectattr('id', 'equalto', 'pv_output_power') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+
+    - name: "Battery Voltage"
+      state: >
+        {% set bt_items = state_attr('sensor.inverter_data', 'bt_') %}
+        {{ (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_28') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "Battery Current"
+      state: >
+        {% set bt_items = state_attr('sensor.inverter_data', 'bt_') %}
+        {{ (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_29') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "A"
+      device_class: "current"
+      state_class: "measurement"
+
+    - name: "Battery Power"
+      state: >
+        {% set bt_items = state_attr('sensor.inverter_data', 'bt_') %}
+        {% set battery_voltage = (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_28') | map(attribute='val') | first) | float %}
+        {% set battery_current = (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_29') | map(attribute='val') | first) | float %}
+        {{ (battery_voltage * battery_current) | float }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+
+    - name: "Load Output Voltage"
+      state: >
+        {% set bc_items = state_attr('sensor.inverter_data', 'bc_') %}
+        {{ (bc_items | selectattr('id', 'equalto', 'bc_eybond_read_23') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "Load Power"
+      state: >
+        {% set bc_items = state_attr('sensor.inverter_data', 'bc_') %}
+        {{ (bc_items | selectattr('id', 'equalto', 'bc_load_active_power') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"


### PR DESCRIPTION
## Summary

Adds a Home Assistant sensor template for the **Anenji® 4200 Watt 24Vdc 220Vac** inverter, requested in [issue #22](https://github.com/SilverFire/dessmonitor-homeassistant/issues/22).

## Changes

- **`src/anenji.yaml`** — new template converting the sensor list from issue #22 into the project's standard format (`- sensor:` wrapper, `sensor.inverter_data` attribute source, `state >` style), matching the existing `eg4.yaml`/`powmr.yaml` conventions. Sensors: Grid Voltage/Frequency/Power, AC Charging Current, PV1 Voltage/Current/Power, Battery Voltage/Current/Power, Load Output Voltage, Load Power.
- **`README.md`** — added "Anenji® 4200 Watt 24Vdc 220Vac" to the supported brands list and a new row in the template table crediting @itgenmar / issue #22.

## Reviewer notes

- Kept `device_class: "power"` for power sensors (as supplied in the issue) rather than the `"energy"` value used in `eg4.yaml`, since `"power"` is the correct class for W measurements.
- Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)