### PR TITLE
Add generic EASUN inverter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The following devices are checked to be supported by the API:
     - EG4® 3000EHV-48 All-In-One Off-Grid Inverter
 - **Anenji®**
     - Anenji® 4200 Watt 24Vdc 220Vac
+- **EASUN®**
+    - EASUN® 3.2kW (generic)
 
 ## Exported sensors
 
@@ -129,6 +131,7 @@ The following sensors are available via the API:
 | PowMr               | [powmr.yaml](src/powmr.yaml)                                                                                                                                                                                                                                | @lawyerhome @ [issue #1](https://github.com/SilverFire/dessmonitor-homeassistant/issues/1) |
 | EG4®                | [eg4.yaml](src/eg4.yaml)                                                                                                                                                                                                                                    | @Joannou1 @ [issue #3](https://github.com/SilverFire/dessmonitor-homeassistant/issues/3)   |
 | Anenji®             | [anenji.yaml](src/anenji.yaml)                                                                                                                                                                                                                              | @itgenmar @ [issue #22](https://github.com/SilverFire/dessmonitor-homeassistant/issues/22) |
+| EASUN® (generic)    | [easun.yaml](src/easun.yaml)                                                                                                                                                                                                                                | @josgirrui @ [PR #19](https://github.com/SilverFire/dessmonitor-homeassistant/pull/19)     |
 | Other               | Try using the Sorotec template and adjust if it doesn't work. See [issue #1](https://github.com/SilverFire/dessmonitor-homeassistant/issues/1) as an example. Feel free to submit an issue or a pull request to share your effort with other enthusiasts 🙌 |                                                                                            |
 
 4. Include the `template.yaml` in your `configuration.yaml`:

--- a/src/easun.yaml
+++ b/src/easun.yaml
@@ -1,0 +1,91 @@
+- sensor:
+    - name: "Grid Voltage"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_eybond_read_15') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "Grid Frequency"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_eybond_read_16') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "Hz"
+      device_class: "frequency"
+      state_class: "measurement"
+
+    - name: "Grid Power"
+      state: >
+        {% set gd_items = state_attr('sensor.inverter_data', 'gd_') %}
+        {{ (gd_items | selectattr('id', 'equalto', 'gd_grid_active_power') | map(attribute='val') | first) | int }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+
+    - name: "PV1 Voltage"
+      state: >
+        {% set pv_items = state_attr('sensor.inverter_data', 'pv_') %}
+        {{ (pv_items | selectattr('id', 'equalto', 'pv_eybond_read_32') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "PV1 Current"
+      state: >
+        {% set pv_items = state_attr('sensor.inverter_data', 'pv_') %}
+        {{ (pv_items | selectattr('id', 'equalto', 'pv_eybond_read_33') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "A"
+      device_class: "current"
+      state_class: "measurement"
+
+    - name: "PV1 Power"
+      state: >
+        {% set pv_items = state_attr('sensor.inverter_data', 'pv_') %}
+        {{ (pv_items | selectattr('id', 'equalto', 'pv_output_power') | map(attribute='val') | first) | int }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+
+    - name: "Battery Voltage"
+      state: >
+        {% set bt_items = state_attr('sensor.inverter_data', 'bt_') %}
+        {{ (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_28') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "Battery Current"
+      state: >
+        {% set bt_items = state_attr('sensor.inverter_data', 'bt_') %}
+        {{ (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_29') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "A"
+      device_class: "current"
+      state_class: "measurement"
+
+    - name: "Battery SOC"
+      state: >
+        {% set bt_items = state_attr('sensor.inverter_data', 'bt_') %}
+        {% set voltage = (bt_items | selectattr('id', 'equalto', 'bt_eybond_read_28') | map(attribute='val') | first) | float %}
+        {# Example linear approximation between 21V (0%) and 28.8V (100%) for 24V battery #}
+        {% set soc = ((voltage - 21) / (28.8 - 21)) * 100 %}
+        {{ [0, [100, soc]| min]| max| round(1) }}
+      unit_of_measurement: "%"
+      device_class: "battery"
+      state_class: "measurement"
+
+    - name: "Load Output Voltage"
+      state: >
+        {% set bc_items = state_attr('sensor.inverter_data', 'bc_') %}
+        {{ (bc_items | selectattr('id', 'equalto', 'bc_eybond_read_23') | map(attribute='val') | first) | float }}
+      unit_of_measurement: "V"
+      device_class: "voltage"
+      state_class: "measurement"
+
+    - name: "Load Power"
+      state: >
+        {% set bc_items = state_attr('sensor.inverter_data', 'bc_') %}
+        {{ (bc_items | selectattr('id', 'equalto', 'bc_load_active_power') | map(attribute='val') | first) | int }}
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"


### PR DESCRIPTION
## Summary

Adds a generic Home Assistant sensor template for **EASUN** inverters (tested on an EASUN 3.2kW). Supersedes and incorporates [PR #19](https://github.com/SilverFire/dessmonitor-homeassistant/pull/19) by @josgirrui, reformatted to match the project's existing template conventions.

## Changes

- **`src/easun.yaml`** — new template using the standard `- sensor:` wrapper and `sensor.inverter_data` attribute source (consistent with `eg4.yaml`/`anenji.yaml`). Sensors: Grid Voltage/Frequency/Power, PV1 Voltage/Current/Power, Battery Voltage/Current/SOC, Load Output Voltage, Load Power.
- **`README.md`** — added "EASUN® 3.2kW (generic)" to the supported brands list and a template-table row crediting @josgirrui / PR #19.

## Reviewer notes

- Battery SOC is a linear voltage approximation (21V = 0%, 28.8V = 100%) for a 24V battery, as provided by the original author — may need tuning per battery chemistry.
- Original author noted the grid and solar parts were not fully tested.
- Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)